### PR TITLE
Actualización de permisos de roles

### DIFF
--- a/FinancialBudget.Server/Context/Config/RolOperationConfig.cs
+++ b/FinancialBudget.Server/Context/Config/RolOperationConfig.cs
@@ -258,6 +258,17 @@ namespace FinancialBudget.Server.Context.Config
                 {
                     Id = 22,
                     RolId = 2,
+                    OperationId = 2,
+                    State = 1,
+                    CreatedAt = new DateTime(2025, 2, 17, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                    CreatedBy = 1,
+                    UpdatedAt = null,
+                    UpdatedBy = null
+                },
+                new RolOperation
+                {
+                    Id = 23,
+                    RolId = 2,
                     OperationId = 5,
                     State = 1,
                     CreatedAt = new DateTime(2025, 2, 17, 0, 0, 0, 0, DateTimeKind.Unspecified),
@@ -268,7 +279,7 @@ namespace FinancialBudget.Server.Context.Config
                 //Rol Mantenimiento
                  new RolOperation
                  {
-                     Id = 23,
+                     Id = 24,
                      RolId = 3,
                      OperationId = 1,
                      State = 1,
@@ -277,9 +288,20 @@ namespace FinancialBudget.Server.Context.Config
                      UpdatedAt = null,
                      UpdatedBy = null
                  },
+                 new RolOperation
+                 {
+                     Id = 25,
+                     RolId = 3,
+                     OperationId = 2,
+                     State = 1,
+                     CreatedAt = new DateTime(2025, 2, 17, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                     CreatedBy = 1,
+                     UpdatedAt = null,
+                     UpdatedBy = null
+                 },
                 new RolOperation
                 {
-                    Id = 24,
+                    Id = 26,
                     RolId = 3,
                     OperationId = 5,
                     State = 1,

--- a/FinancialBudget.Server/Migrations/20251023024906_add Rol Permissions.Designer.cs
+++ b/FinancialBudget.Server/Migrations/20251023024906_add Rol Permissions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinancialBudget.Server.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinancialBudget.Server.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251023024906_add Rol Permissions")]
+    partial class addRolPermissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FinancialBudget.Server/Migrations/20251023024906_add Rol Permissions.cs
+++ b/FinancialBudget.Server/Migrations/20251023024906_add Rol Permissions.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace FinancialBudget.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class addRolPermissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Operations",
+                keyColumn: "Id",
+                keyValue: 7L,
+                column: "Icon",
+                value: "bi bi-people");
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 22L,
+                column: "OperationId",
+                value: 2L);
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 23L,
+                columns: new[] { "OperationId", "RolId" },
+                values: new object[] { 5L, 2L });
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 24L,
+                column: "OperationId",
+                value: 1L);
+
+            migrationBuilder.InsertData(
+                table: "RolOperations",
+                columns: new[] { "Id", "CreatedAt", "CreatedBy", "OperationId", "RolId", "State", "UpdatedAt", "UpdatedBy" },
+                values: new object[,]
+                {
+                    { 25L, new DateTimeOffset(new DateTime(2025, 2, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, -6, 0, 0, 0)), 1L, 2L, 3L, 1, null, null },
+                    { 26L, new DateTimeOffset(new DateTime(2025, 2, 17, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, -6, 0, 0, 0)), 1L, 5L, 3L, 1, null, null }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 25L);
+
+            migrationBuilder.DeleteData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 26L);
+
+            migrationBuilder.UpdateData(
+                table: "Operations",
+                keyColumn: "Id",
+                keyValue: 7L,
+                column: "Icon",
+                value: "bi bi-list");
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 22L,
+                column: "OperationId",
+                value: 5L);
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 23L,
+                columns: new[] { "OperationId", "RolId" },
+                values: new object[] { 2L, 3L });
+
+            migrationBuilder.UpdateData(
+                table: "RolOperations",
+                keyColumn: "Id",
+                keyValue: 24L,
+                column: "OperationId",
+                value: 5L);
+        }
+    }
+}


### PR DESCRIPTION
Se han agregado nuevas instancias de `RolOperation` con los IDs 22, 23, 24, 25 y 26 en `RolOperationConfig.cs`. Se han actualizado los IDs existentes para reflejar estos cambios. En `DataContextModelSnapshot.cs`, se ha cambiado el icono de la operación con ID 7 y se han ajustado los IDs y relaciones de `RolOperation`. Se ha añadido una nueva migración `20251023024906_add Rol Permissions.cs` para actualizar los datos de las tablas `Operations` y `RolOperations`, e insertar nuevos datos. También se ha generado un archivo de diseñador para reflejar el modelo de datos actualizado.