### PR TITLE
Migrar backend de SQL Server a PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Este repositorio proporciona una plantilla inicial para construir una aplicació
 - 🔐 Autenticación lista con JWT (`Microsoft.AspNetCore.Authentication.JwtBearer`)
 - 🔁 Automapeo de entidades con [Mapster](https://github.com/MapsterMapper/Mapster)
 - 💡 Inyección de dependencias ya configurada
-- 🗃️ Entity Framework Core + SQL Server
+- 🗃️ Entity Framework Core + PostgreSQL
 - 🧪 Validaciones con [FluentValidation](https://docs.fluentvalidation.net/)
 - 🔎 Documentación de API con Swagger (Swashbuckle)
-- 🔥 Logging estructurado con Serilog (con almacenamiento en SQL Server)
+- 🔥 Logging estructurado con Serilog (con almacenamiento en PostgreSQL)
 - ⚛️ Frontend en React + TypeScript
 - ⚙️ SPA Proxy configurado para desarrollo en simultáneo
 


### PR DESCRIPTION
Se ha actualizado la configuración del backend para utilizar PostgreSQL en lugar de SQL Server. Esto incluye el cambio en la descripción del uso de Entity Framework Core y el almacenamiento para el logging estructurado con Serilog.